### PR TITLE
Workaround for weird librmn behaviour when filename is all capitals.

### DIFF
--- a/lib/rpnpy/librmn/base.py
+++ b/lib/rpnpy/librmn/base.py
@@ -187,6 +187,9 @@ def fnom(filename, filemode=_rc.FST_RW, iunit=0):
     if not isinstance(filemode, str):
         raise TypeError("fnom: Expecting arg filemode of type str, Got {0}"\
                         .format(type(filemode)))
+    # Prepend filename with '+' to tell librmn to preserve filename case.
+    if not filename.startswith('+'):
+      filename = '+'+filename
     istat = _rp.c_fnom(_ct.byref(ciunit), _C_WCHAR2CHAR(filename),
                        _C_WCHAR2CHAR(filemode), 0)
     istat = _C_TOINT(istat)
@@ -264,6 +267,9 @@ def wkoffit(filename):
                         "Got {0}".format(type(filename)))
     if filename.strip() == '':
         raise ValueError("wkoffit: must provide a valid filename")
+    # Prepend filename with '+' to tell librmn to preserve filename case.
+    if not filename.startswith('+'):
+      filename = '+'+filename
     return _rp.c_wkoffit(_C_WCHAR2CHAR(filename), len(filename))
 
 


### PR DESCRIPTION
Fixes issue #12.