### PR TITLE
Use zlib.crc32 instead of librmn.crc32.

### DIFF
--- a/lib/rpnpy/librmn/base.py
+++ b/lib/rpnpy/librmn/base.py
@@ -24,6 +24,7 @@ See Also:
 
 import ctypes as _ct
 import numpy  as _np
+import zlib   as _zl
 from rpnpy.librmn import proto as _rp
 from rpnpy.librmn import const as _rc
 from rpnpy.librmn import RMNError
@@ -292,7 +293,7 @@ def crc32(crc, buf):
     """
     if not (buf.dtype == _np.uint32 and buf.flags['F_CONTIGUOUS']):
         buf = _np.asfortranarray(buf, dtype=_np.uint32)
-    return _rp.c_crc32(crc, buf, buf.size*4)
+    return _zl.crc32(buf, crc) & 0xffffffff
 
 #--- base -----------------------------------------------------------
 

--- a/lib/rpnpy/librmn/proto.py
+++ b/lib/rpnpy/librmn/proto.py
@@ -76,19 +76,6 @@ Details:
            l1   (int) : (I) length of nom
         Returns:
            int, file type code
-
-    c_crc32():
-        Compute the Cyclic Redundancy Check (CRC)
-        Proto:
-           unsigned int crc32(unsigned int crc, const unsigned char *buf,
-                              unsigned int lbuf)
-        Args:
-           crc  (int) : (I) initial crc
-           buf        : (I) list of params to compute updated crc
-                            (numpy.ndarray of type uint32)
-           lbuf (int) : (I) length of buf*4
-        Returns:
-           int, Cyclic Redundancy Check number
 </source>
 
 
@@ -1463,18 +1450,6 @@ librmn.c_wkoffit.argtypes = (_ct.c_char_p, _ct.c_int)
 librmn.c_wkoffit.restype  = _ct.c_int
 c_wkoffit = librmn.c_wkoffit
 
-librmn.crc32.argtypes = (
-    _ct.c_uint,
-    _npc.ndpointer(dtype=_np.uint32),
-    _ct.c_uint
-    )
-## librmn.crc32.argtypes = (
-##     _ct.c_int,
-##     _npc.ndpointer(dtype=_np.uint32),
-##     _ct.c_int
-##     )
-librmn.crc32.restype  = _ct.c_uint
-c_crc32 = librmn.crc32
 
 #--- base -----------------------------------------------------------
 


### PR DESCRIPTION
The latter is removed in librmn 016.3 (see https://github.com/armnlib/librmn/commit/686e512be455beec14426592a8bbc5f58b551286).

Closes #17.