### PR TITLE
Add missing rpnpy.range reference for Python 3.

### DIFF
--- a/lib/rpnpy/__init__.py
+++ b/lib/rpnpy/__init__.py
@@ -7,7 +7,7 @@ if sys.version_info < (3,):
 else:
     integer_types = (int,)
     long = int
-    # xrange = range
+    range = range
 
 C_WCHAR2CHAR = lambda x: bytes(str(x).encode('ascii'))
 C_WCHAR2CHAR.__doc__ = 'Convert str to bytes'


### PR DESCRIPTION
Fixes Python 3 functionality after introduction of 400d1195f63ade1aaf9e58e91515634e2afc90ae.