### PR TITLE
Add a setup.py script for this package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE VERSION DESCRIPTION KnownIssues

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+# Include the license file in all binary distributions.
+[metadata]
+license_file = LICENSE
+
+# Build universal wheels (that run on Python 2 or 3).
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup, find_packages
+import sys
+from glob import glob
+import os
+
+# Build version file.
+from subprocess import check_call
+versionfile = os.path.join('lib','rpnpy','version.py')
+makefile = os.path.join('include','Makefile.local.rpnpy.mk')
+if os.path.exists(makefile):
+  if os.path.exists(versionfile):
+    os.remove(versionfile)
+  check_call(['make','-f','include/Makefile.local.rpnpy.mk','rpnpy_version.py'], env={'rpnpy':'.'})
+
+# Add './lib' to the search path, so we can access the version info.
+sys.path.append('lib')
+from rpnpy.version import __VERSION__
+
+
+setup (
+  name = 'eccc_rpnpy',
+  version = __VERSION__,
+  description = 'A Python interface for the RPN libraries at Environment and Climate Change Canada',
+  long_description = open('DESCRIPTION').read(),
+  url = 'https://github.com/meteokid/python-rpn',
+  author = 'Stephane Chamberland',
+  license = 'LGPL-2.1',
+  keywords = 'rpnpy python-rpn vgrid libdescrip librmn rmnlib',
+  packages = find_packages('lib'),
+  py_modules = ['Fstdc','rpn_helpers','rpnstd'],
+  scripts = glob('bin/rpy.*'),
+  package_dir = {'':'lib'},
+  install_requires = ['numpy','pytz'],
+)


### PR DESCRIPTION
Allows the package to be built / installed easily into a virtualenv.

Examples:
```
# To build a source distribution:
python setup.py sdist

# To build a universal wheel:
python setup.py bdist_wheel

# To install this package in "editable" mode:
pip install -e .

# To uninstall:
pip uninstall eccc-rpnpy
```
The package name (from pip's perspective) is **eccc-rpnpy**.  This is to avoid
conflicts with existing PyPI projects that pip sees (lots of reverse-Polish-
notation calculators out there!).  This does not affect the module name, you
would still use "`import rpnpy`" in the scripts.

Note that the shared library paths (librmn, vgrid, libburp) will need to be
provided through some other mechanism.  Unlike SSM, there's no hooks to set
environment variables at startup.  Same goes for ATM_MODEL_DFILES, etc.